### PR TITLE
Fix cart creation in cart.js

### DIFF
--- a/src/Leaphly/ContentBundle/Resources/public/js/cart.js
+++ b/src/Leaphly/ContentBundle/Resources/public/js/cart.js
@@ -106,10 +106,21 @@
             var route = Routing.generate(
                 this.urls['post'],{_format: "json"}
             );
-            $.post(route, null, function(data, text, xhr) {
-
-                return that.fetch_location(xhr.getResponseHeader('location'));
-            })
+            $.ajax({
+                url: route,
+                type: 'POST',
+                success: function(xhr, status, error) {
+                    return that.fetch_location(xhr.getResponseHeader('location'));
+                },
+                // jquery treats an empty response as a parse error
+                error: function(xhr, status, error) {
+                    if(xhr.status == 201) {
+                        return that.fetch_location(xhr.getResponseHeader('location'));
+                    } else {
+                        that.handleError(xhr);
+                    }
+                }
+            });
         },
         delete: function(id){
             var that = this;

--- a/src/Leaphly/ContentBundle/Resources/views/Snippets/cartPost.html.twig
+++ b/src/Leaphly/ContentBundle/Resources/views/Snippets/cartPost.html.twig
@@ -9,7 +9,7 @@
 <pre><code class="php">$cart = $this->container->get('leaphly_cart.cart.handler')->post();
 
 // get the cart given the $cartId
-$cart = $this->container->get('leaphly_cart.cart.handler')->get($cartId);</code></pre>
+$cart = $this->container->get('leaphly_cart.cart.handler')->getCart($cartId);</code></pre>
         </div>
         <div class="tab-pane fade" id="snippet-create-cart-php-rest">
 <pre><code class="php">use Guzzle\Http\Client;


### PR DESCRIPTION
Quick fix for later versions of jquery where an empty response throws a 'parseerror' and won't call the success callback.
Possible fix for #9
